### PR TITLE
added no restore bubbles variant

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,9 @@ First we ill comment out the @xscreensaver line by  adding a hashtag (#) and the
 @xset -dpms
 
 @chromium-browser --noerrdialogs --kiosk --incognito http://www.domain.com/to/kiosk/page
+or
+@chromium-browser --noerrdialogs --disable-session-crashed-bubble --disable-infobars --kiosk http://www.domain.com/to/kiosk/page
+
 ```
 
 


### PR DESCRIPTION
For the cases when required page has authorization incognito mode doesn't work. 
"--disable-session-crashed-bubble --disable-infobars" arguments handle unexpected power cutoffs.